### PR TITLE
Fix for AppVeyor SSL problems

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ install:
       $SDL_MIXER_VERSION = "2.0.2"
       $SDL2MIXERDIR = "C:\sdl_root\SDL2_mixer-$SDL_MIXER_VERSION"
       if (!(Test-Path -Path $SDL2MIXERDIR)) {
+        [Net.ServicePointManager]::SecurityProtocol = 'Ssl3, Tls, Tls11, Tls12'
         Start-FileDownload https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-$SDL_MIXER_VERSION-VC.zip
         7z x SDL2_mixer-devel-$SDL_MIXER_VERSION-VC.zip -aoa -oC:\sdl_root\
       }


### PR DESCRIPTION
Relax SSL supported versions, according to their docs