### PR TITLE
Make some code portability changes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -431,7 +431,7 @@ void load_config_from_command_line(int argc, char **argv)
 char *get_full_path(const char *base_dir, const char *filename)
 {
     char *path = (char *)malloc(strlen(base_dir) + strlen(filename) + 2); //2 = path delimiter + \0
-    sprintf(path, "%s%c%s", base_dir, '/', filename); //FIXME handle windows path separator
+    sprintf(path, "%s%c%s", base_dir, PATH_SEPARATOR, filename);
     return path;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -7,6 +7,12 @@
 #include <SDL_keycode.h>
 #include "defines.h"
 
+#if defined(WIN32) || defined(_WIN32)
+#define PATH_SEPARATOR '\\'
+#else
+#define PATH_SEPARATOR '/'
+#endif
+
 void load_config_file();
 void write_config_file();
 

--- a/src/video.c
+++ b/src/video.c
@@ -78,8 +78,13 @@ bool video_init()
     renderer = SDL_CreateRenderer( window, -1, SDL_RENDERER_ACCELERATED );
     if(renderer == NULL)
     {
-        printf("Error: creating render. %s\n", SDL_GetError());
-        return false;
+        //Fallback to software renderer if accelerated fails
+        renderer = SDL_CreateRenderer( window, -1, SDL_RENDERER_SOFTWARE );
+        if(renderer == NULL)
+        {
+            printf("Error: creating render. %s\n", SDL_GetError());
+            return false;
+        }
     }
 
     init_surface(&game_surface, SCREEN_WIDTH, SCREEN_HEIGHT);


### PR DESCRIPTION
These simple changes should improve portability across various systems.
1. I added a software renderer fallback incase the SDL subsystem does not support hardware acceleration
2. #ifdef in windows path separator `\\`

These changes allowed me to compile for the Original Xbox for example :)

