### PR TITLE
Input: Add SDL_GameController Backend

### DIFF
--- a/src/dialog.c
+++ b/src/dialog.c
@@ -90,9 +90,11 @@ HintDialogInput hint_dialog_get_input(HintDialogInput input)
     SDL_Event event;
     while(SDL_PollEvent(&event))
     {
-        if (event.type == SDL_KEYDOWN)
+        if (event.type == SDL_KEYDOWN ||
+            event.type == SDL_CONTROLLERBUTTONDOWN)
         {
-            if(event.key.keysym.sym == SDLK_SPACE)
+            if (event.key.keysym.sym == SDLK_SPACE ||
+                event.cbutton.button == SDL_CONTROLLER_BUTTON_A)
             {
                 return FAST_FORWARD;
             }
@@ -101,7 +103,8 @@ HintDialogInput hint_dialog_get_input(HintDialogInput input)
                 return EXIT;
             }
         }
-        if (event.type == SDL_KEYUP && event.key.keysym.sym == SDLK_SPACE)
+        if ((event.type == SDL_KEYUP && event.key.keysym.sym == SDLK_SPACE) ||
+            (event.type == SDL_CONTROLLERBUTTONUP && event.cbutton.button == SDL_CONTROLLER_BUTTON_A))
         {
             return NO_INPUT;
         }

--- a/src/input.h
+++ b/src/input.h
@@ -35,6 +35,9 @@ extern uint8 right_key_pressed;
 
 extern uint8 byte_2E17C;
 
+void input_init();
+void input_shutdown();
+
 void wait_for_time_or_key(int delay_in_game_cycles);
 input_state_enum read_input();
 void reset_player_control_inputs();

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include "high_scores.h"
 #include "demo.h"
 #include "b800.h"
+#include "input.h"
 
 int cleanup_and_exit();
 
@@ -26,6 +27,7 @@ int main(int argc, char *argv[]) {
 
     video_init();
     audio_init();
+    input_init();
     game_init();
 
     video_fill_screen_with_black();
@@ -71,6 +73,7 @@ int cleanup_and_exit()
     config_cleanup();
     video_shutdown();
     audio_shutdown();
+    input_shutdown();
     SDL_Quit();
 
     return 0;


### PR DESCRIPTION
I wrote a SDL_GameController backend for a port I am working on.

I appreciate there is probably many ways of doing this so will leave up to the author of this repo if they would like to merge or they had something else in mind. Happy to make changes if requested.

Benefits of this way:
* SDL_Gamecontroller provides a consistent button mapping across a range of controllers
* `gamecontroller_to_keyboard()` in `input.c` has been added to convert button events to SDL_Keycodes to integrate with the existing code base as much as possible.
* Keyboard input game controller input can both work at the same time

Current the mapping is as follows but happy to change based on feedback
* SDL_CONTROLLER_BUTTON_A = cfg_jump_key
* SDL_CONTROLLER_BUTTON_X/B = cfg_bomb_key
* SDL_CONTROLLER_BUTTON_DPAD = Arrow keys
* SDL_CONTROLLER_BUTTON_START = ENTER
* SDL_CONTROLLER_BUTTON_BACK= q (quit_game_dialog)
* SDL_CONTROLLER_BUTTON_Y = ESCAPE (help_menu_dialog)

What it doesn't do:
* Button mapping is hardcoded. The menu option to redefine joystick mapping still isnt enabled (SDL_Gamecontroller should provide a fairly consistent experience)
* No way of entering text for high score screen etc. This is how the original game would have behaved.
* In game dialog text still shows keyboard mapping. This is how the original game would have behaved I think?

I have tested with my wired Xbox360 controller.

This will potentially close issue #12 
