### PR TITLE
Fix malloc/SDL_free mismatch causing crash on Windows

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -95,7 +95,7 @@ void load_config_file()
     File file;
     clear_high_score_table();
     int config_file_loaded = file_open(path, "rb", &file);
-    free(path);
+    SDL_free(path);
 
     if(config_file_loaded)
     {
@@ -147,7 +147,7 @@ void write_config_file()
     char *path = get_save_dir_full_path(get_config_filename());
     File file;
     int status = file_open(path, "wb", &file);
-    free(path);
+    SDL_free(path);
 
     if(!status)
     {
@@ -458,7 +458,7 @@ void load_config_from_command_line(int argc, char **argv)
 
 char *get_full_path(const char *base_dir, const char *filename)
 {
-    char *path = (char *)malloc(strlen(base_dir) + strlen(filename) + 2); //2 = path delimiter + \0
+    char *path = (char *)SDL_malloc(strlen(base_dir) + strlen(filename) + 2); //2 = path delimiter + \0
     sprintf(path, "%s%c%s", base_dir, '/', filename); //FIXME handle windows path separator
     return path;
 }

--- a/src/input.c
+++ b/src/input.c
@@ -64,7 +64,7 @@ bool input_init() {
     char * mappingFilename = get_data_dir_full_path("gamecontrollerdb.txt");
     int numMappings = SDL_GameControllerAddMappingsFromFile(mappingFilename);
     SDL_Log("Game controllers found: %d Mappings: \'%s\' Count: %d", SDL_NumJoysticks(), mappingFilename, numMappings);
-    free(mappingFilename);
+    SDL_free(mappingFilename);
 
     for (int i = 0; i < SDL_NumJoysticks(); ++i) {
         if (SDL_IsGameController(i)) {

--- a/src/save.c
+++ b/src/save.c
@@ -18,7 +18,7 @@
  *
  */
 
-#include <stdlib.h>
+#include <SDL.h>
 #include "save.h"
 #include "defines.h"
 #include "player.h"
@@ -58,10 +58,10 @@ void write_savegame_file(char suffix)
         if(!file_open(path, "wb", &savefile))
         {
             printf("Error: saving file %s\n", path);
-            free(path);
+            SDL_free(path);
             return;
         }
-        free(path);
+        SDL_free(path);
 
         file_write2(health, &savefile);
         file_write4(score, &savefile);
@@ -134,7 +134,7 @@ SaveStatus load_savegame_data_from_file(char suffix, SaveGameData *data) {
 
     path = get_save_dir_full_path(filename);
     int status = file_open(path, "rb", &file);
-    free(path);
+    SDL_free(path);
 
     if(!status)
     {


### PR DESCRIPTION
Use `SDL_malloc` in `get_full_path(`) and `SDL_free` consistently across all callers to avoid memory allocator mismatch. Newer SDL builds on Windows use a different allocator than the standard C library, causing crashes when mixing `malloc()` with `SDL_free()`.

Fixes #22 